### PR TITLE
feat: Expose deal/contact fields in task UI and API

### DIFF
--- a/Controller/Api/TaskApiController.php
+++ b/Controller/Api/TaskApiController.php
@@ -12,10 +12,13 @@ use Mautic\CoreBundle\Helper\AppVersion;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Translation\Translator;
+use Mautic\UserBundle\Entity\User;
 use MauticPlugin\MautomicCrmBundle\Entity\Task;
 use MauticPlugin\MautomicCrmBundle\Model\TaskModel;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -47,5 +50,56 @@ class TaskApiController extends CommonApiController
         $this->permissionBase  = 'mautomic_crm:tasks';
 
         parent::__construct($security, $translator, $entityResultHelper, $router, $formFactory, $appVersion, $requestStack, $doctrine, $modelFactory, $dispatcher, $coreParametersHelper);
+    }
+
+    /**
+     * @param Task $entity
+     */
+    protected function createEntityForm($entity): FormInterface
+    {
+        $form = parent::createEntityForm($entity);
+
+        $form->remove('owner');
+
+        return $form;
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     * @param Task                 $entity
+     * @param string               $action
+     *
+     * @return array<string, mixed>
+     */
+    protected function prepareParametersForBinding(Request $request, $parameters, $entity, $action): array
+    {
+        if (!array_key_exists('deal', $parameters) && $entity->getDeal()) {
+            $parameters['deal'] = $entity->getDeal()->getId();
+        }
+
+        if (!array_key_exists('contact', $parameters) && $entity->getContact()) {
+            $parameters['contact'] = $entity->getContact()->getId();
+        }
+
+        unset($parameters['owner']);
+
+        return $parameters;
+    }
+
+    /**
+     * @param Task                 $entity
+     * @param FormInterface<Task>  $form
+     * @param array<string, mixed> $parameters
+     * @param string               $action
+     */
+    protected function preSaveEntity(&$entity, $form, $parameters, $action = 'edit'): void
+    {
+        if (!empty($this->entityRequestParameters['owner'])) {
+            $ownerId = (int) $this->entityRequestParameters['owner'];
+            $em      = $this->doctrine->getManager();
+            \assert($em instanceof \Doctrine\ORM\EntityManagerInterface);
+            $owner = $em->getReference(User::class, $ownerId);
+            $entity->setOwner($owner);
+        }
     }
 }

--- a/Resources/views/Task/details.html.twig
+++ b/Resources/views/Task/details.html.twig
@@ -46,6 +46,22 @@
                   <td>{{ ('mautomic_crm.task.status.' ~ item.status)|trans }}</td>
               </tr>
               <tr>
+                  <td><span class="fw-b">{{ 'mautomic_crm.task.deal'|trans }}</span></td>
+                  <td>{% if item.deal %}
+                      <a data-toggle="ajax" href="{{ path('mautic_mautomic_crm_deal_action', {'objectAction': 'view', 'objectId': item.deal.id}) }}">
+                          {{ item.deal.name }}
+                      </a>
+                  {% else %}-{% endif %}</td>
+              </tr>
+              <tr>
+                  <td><span class="fw-b">{{ 'mautomic_crm.task.contact'|trans }}</span></td>
+                  <td>{% if item.contact %}
+                      <a data-toggle="ajax" href="{{ path('mautic_contact_action', {'objectAction': 'view', 'objectId': item.contact.id}) }}">
+                          {{ item.contact.name }}
+                      </a>
+                  {% else %}-{% endif %}</td>
+              </tr>
+              <tr>
                   <td><span class="fw-b">{{ 'mautomic_crm.task.owner'|trans }}</span></td>
                   <td>{% if item.owner %}{{ item.owner.name }}{% else %}-{% endif %}</td>
               </tr>

--- a/Resources/views/Task/form.html.twig
+++ b/Resources/views/Task/form.html.twig
@@ -21,6 +21,10 @@
                 <div class="col-md-12">{{ form_row(form.description) }}</div>
             </div>
             <div class="row">
+                <div class="col-md-6">{{ form_row(form.deal) }}</div>
+                <div class="col-md-6">{{ form_row(form.contact) }}</div>
+            </div>
+            <div class="row">
                 <div class="col-md-4">{{ form_row(form.dueDate) }}</div>
                 <div class="col-md-4">{{ form_row(form.priority) }}</div>
                 <div class="col-md-4">{{ form_row(form.status) }}</div>

--- a/Tests/Functional/Controller/Api/TaskApiControllerTest.php
+++ b/Tests/Functional/Controller/Api/TaskApiControllerTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\MautomicCrmBundle\Tests\Functional\Controller\Api;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\Lead;
+use MauticPlugin\MautomicCrmBundle\Entity\Deal;
+use MauticPlugin\MautomicCrmBundle\Entity\Pipeline;
+use MauticPlugin\MautomicCrmBundle\Entity\Stage;
+use Symfony\Component\HttpFoundation\Response;
+
+class TaskApiControllerTest extends MauticMysqlTestCase
+{
+    private int $dealId;
+    private int $contactId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $pipeline = new Pipeline();
+        $pipeline->setName('API Test Pipeline');
+        $pipeline->setIsPublished(true);
+
+        $stage = new Stage();
+        $stage->setName('Prospecting');
+        $stage->setOrder(1);
+        $stage->setProbability(10);
+        $stage->setType('open');
+        $stage->setPipeline($pipeline);
+        $pipeline->addStage($stage);
+
+        $this->em->persist($pipeline);
+        $this->em->persist($stage);
+
+        $deal = new Deal();
+        $deal->setName('API Test Deal');
+        $deal->setPipeline($pipeline);
+        $deal->setStage($stage);
+        $deal->setIsPublished(true);
+        $this->em->persist($deal);
+
+        $contact = new Lead();
+        $contact->setFirstname('John');
+        $contact->setLastname('Doe');
+        $contact->setEmail('john.doe@example.com');
+        $this->em->persist($contact);
+
+        $this->em->flush();
+
+        $this->dealId    = $deal->getId();
+        $this->contactId = $contact->getId();
+    }
+
+    public function testCreateTaskWithDealViaApi(): void
+    {
+        $payload = [
+            'title'       => 'Follow up with client',
+            'status'      => 'open',
+            'priority'    => 'high',
+            'deal'        => $this->dealId,
+            'isPublished' => true,
+        ];
+
+        $this->client->request('POST', '/api/mautomic/tasks/new', $payload);
+        $clientResponse = $this->client->getResponse();
+        $response       = json_decode($clientResponse->getContent(), true);
+
+        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertArrayHasKey('task', $response);
+        $this->assertSame('Follow up with client', $response['task']['title']);
+        $this->assertSame($this->dealId, $response['task']['deal']['id']);
+    }
+
+    public function testCreateTaskWithContactViaApi(): void
+    {
+        $payload = [
+            'title'       => 'Call contact',
+            'status'      => 'open',
+            'priority'    => 'normal',
+            'contact'     => $this->contactId,
+            'isPublished' => true,
+        ];
+
+        $this->client->request('POST', '/api/mautomic/tasks/new', $payload);
+        $clientResponse = $this->client->getResponse();
+        $response       = json_decode($clientResponse->getContent(), true);
+
+        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertArrayHasKey('task', $response);
+        $this->assertSame('Call contact', $response['task']['title']);
+        $this->assertSame($this->contactId, $response['task']['contact']['id']);
+    }
+
+    public function testGetTaskIncludesDealAndContact(): void
+    {
+        $payload = [
+            'title'       => 'Full linking test',
+            'status'      => 'open',
+            'priority'    => 'normal',
+            'deal'        => $this->dealId,
+            'contact'     => $this->contactId,
+            'isPublished' => true,
+        ];
+
+        $this->client->request('POST', '/api/mautomic/tasks/new', $payload);
+        $createResponse = json_decode($this->client->getResponse()->getContent(), true);
+        $taskId         = $createResponse['task']['id'];
+
+        $this->client->request('GET', "/api/mautomic/tasks/{$taskId}");
+        $clientResponse = $this->client->getResponse();
+        $response       = json_decode($clientResponse->getContent(), true);
+
+        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        $this->assertSame($taskId, $response['task']['id']);
+        $this->assertSame($this->dealId, $response['task']['deal']['id']);
+        $this->assertSame($this->contactId, $response['task']['contact']['id']);
+    }
+}

--- a/Tests/Functional/Controller/TaskControllerTest.php
+++ b/Tests/Functional/Controller/TaskControllerTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace MauticPlugin\MautomicCrmBundle\Tests\Functional\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use MauticPlugin\MautomicCrmBundle\Entity\Deal;
+use MauticPlugin\MautomicCrmBundle\Entity\Pipeline;
+use MauticPlugin\MautomicCrmBundle\Entity\Stage;
 use MauticPlugin\MautomicCrmBundle\Entity\Task;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -68,5 +71,87 @@ class TaskControllerTest extends MauticMysqlTestCase
         $this->client->request(Request::METHOD_GET, '/s/mautomic/tasks/view/'.$task->getId());
         $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
         $this->assertStringContainsString('View This Task', $this->client->getResponse()->getContent());
+    }
+
+    public function testNewFormHasDealAndContactFields(): void
+    {
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/mautomic/tasks/new');
+        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertGreaterThan(0, $crawler->filter('select[id="task_deal"]')->count(), 'Deal select should exist');
+        $this->assertGreaterThan(0, $crawler->filter('select[id="task_contact"]')->count(), 'Contact select should exist');
+    }
+
+    public function testCreateTaskLinkedToDeal(): void
+    {
+        $pipeline = $this->createPipelineWithStage();
+        $stage    = $pipeline->getStages()->first();
+
+        $deal = new Deal();
+        $deal->setName('Big Corp Deal');
+        $deal->setPipeline($pipeline);
+        $deal->setStage($stage);
+        $deal->setIsPublished(true);
+        $this->em->persist($deal);
+
+        $task = new Task();
+        $task->setTitle('Follow up call');
+        $task->setStatus('open');
+        $task->setPriority('high');
+        $task->setDeal($deal);
+        $task->setIsPublished(true);
+        $this->em->persist($task);
+        $this->em->flush();
+
+        $this->client->request(Request::METHOD_GET, '/s/mautomic/deals/view/'.$deal->getId());
+        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertStringContainsString('Follow up call', $this->client->getResponse()->getContent());
+    }
+
+    public function testOverdueTaskHighlightedOnDealDetail(): void
+    {
+        $pipeline = $this->createPipelineWithStage();
+        $stage    = $pipeline->getStages()->first();
+
+        $deal = new Deal();
+        $deal->setName('Overdue Test Deal');
+        $deal->setPipeline($pipeline);
+        $deal->setStage($stage);
+        $deal->setIsPublished(true);
+        $this->em->persist($deal);
+
+        $task = new Task();
+        $task->setTitle('Overdue task');
+        $task->setStatus('open');
+        $task->setPriority('normal');
+        $task->setDueDate(new \DateTime('-7 days'));
+        $task->setDeal($deal);
+        $task->setIsPublished(true);
+        $this->em->persist($task);
+        $this->em->flush();
+
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/mautomic/deals/view/'.$deal->getId());
+        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertGreaterThan(0, $crawler->filter('tr.text-danger')->count(), 'Overdue task row should have text-danger class');
+    }
+
+    private function createPipelineWithStage(): Pipeline
+    {
+        $pipeline = new Pipeline();
+        $pipeline->setName('Test Pipeline');
+        $pipeline->setIsPublished(true);
+        $this->em->persist($pipeline);
+
+        $stage = new Stage();
+        $stage->setName('Qualification');
+        $stage->setPipeline($pipeline);
+        $stage->setOrder(1);
+        $stage->setProbability(25);
+        $stage->setType('open');
+        $this->em->persist($stage);
+
+        $pipeline->addStage($stage);
+        $this->em->flush();
+
+        return $pipeline;
     }
 }


### PR DESCRIPTION
## Summary
- Add deal and contact dropdown fields to the task form template (new row between description and dueDate/priority/status)
- Show linked deal and contact on task detail view with ajax navigation links
- Implement `createEntityForm()`, `prepareParametersForBinding()`, and `preSaveEntity()` in TaskApiController following the DealApiController pattern
- Add functional tests for form fields, task-deal linking on deal detail page, overdue highlighting, and API CRUD with deal/contact associations

## Test plan
- [ ] `lint-local.sh` passes (PHPStan level 6 + CS Fixer)
- [ ] `test-local.sh` passes (77 unit + 48 functional tests)
- [ ] Browser: navigate to /s/mautomic/tasks/new — verify Deal and Contact dropdowns visible
- [ ] Browser: create task linked to a deal → navigate to deal detail → verify task appears
- [ ] Browser: create overdue task → verify red highlighting on deal detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)