### PR TITLE
fix: Move Deal Fields to admin settings menu

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -109,17 +109,20 @@ return [
                 'parent'   => 'mautomic_crm.crm',
                 'priority' => 20,
             ],
-            'mautomic_crm.deal_fields' => [
-                'route'    => 'mautic_mautomic_crm_deal_field_index',
-                'access'   => 'mautomic_crm:deals:view',
-                'parent'   => 'mautomic_crm.crm',
-                'priority' => 15,
-            ],
             'mautomic_crm.tasks' => [
                 'route'    => 'mautic_mautomic_crm_task_index',
                 'access'   => 'mautomic_crm:tasks:view',
                 'parent'   => 'mautomic_crm.crm',
                 'priority' => 30,
+            ],
+        ],
+        'admin' => [
+            'mautomic_crm.deal_field.list' => [
+                'id'        => 'mautomic_crm_deal_fields',
+                'iconClass' => 'ri-input-field',
+                'route'     => 'mautic_mautomic_crm_deal_field_index',
+                'access'    => 'mautomic_crm:deals:view',
+                'priority'  => 18,
             ],
         ],
     ],


### PR DESCRIPTION
## Summary
- Fixed untranslated menu label (`mautomic_crm.deal_fields` showing raw key)
- Moved Deal Fields from CRM main menu to admin/settings menu, matching Mautic's pattern (Contact Fields is also in admin menu)

## Test plan
- [ ] Verify "Deal Fields" appears in the Settings gear menu with correct label
- [ ] Verify it no longer appears in the main CRM dropdown
- [ ] Verify the page loads correctly from the new menu location