### PR TITLE
docs: Add GPL-3.0-or-later LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,23 @@
+# GNU General Public License v3.0 or later
+
+Copyright (C) 2025 Mautomic
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+---
+
+## Full License Text
+
+The full text of the GNU General Public License v3.0 is available at:
+<https://www.gnu.org/licenses/gpl-3.0.txt>


### PR DESCRIPTION
## Summary
- Adds `LICENSE.md` with the GPL-3.0-or-later license, matching the license declared in `composer.json`.

## Test plan
- No code changes, docs only.