### PR TITLE
Show contact and company on deal form and detail view

### DIFF
--- a/Form/Type/DealType.php
+++ b/Form/Type/DealType.php
@@ -11,6 +11,10 @@ use Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber;
 use Mautic\CoreBundle\Form\EventListener\FormExitSubscriber;
 use Mautic\CoreBundle\Form\Type\FormButtonsType;
 use Mautic\CoreBundle\Form\Type\YesNoButtonGroupType;
+use Mautic\LeadBundle\Entity\Company;
+use Mautic\LeadBundle\Entity\CompanyRepository;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Form\Type\UserListType;
 use MauticPlugin\MautomicCrmBundle\Entity\Deal;
@@ -108,6 +112,33 @@ class DealType extends AbstractType
             'required'      => true,
             'query_builder' => fn (StageRepository $repo) => $repo->createQueryBuilder('s')
                 ->orderBy('s.order', 'ASC'),
+        ]);
+
+        $builder->add('contact', EntityType::class, [
+            'class'         => Lead::class,
+            'choice_label'  => fn (Lead $lead) => $lead->getName() ?: $lead->getEmail() ?: 'Contact #'.$lead->getId(),
+            'label'         => 'mautomic_crm.deal.contact',
+            'label_attr'    => ['class' => 'control-label'],
+            'attr'          => ['class' => 'form-control'],
+            'required'      => false,
+            'placeholder'   => '',
+            'query_builder' => fn (LeadRepository $repo) => $repo->createQueryBuilder('l')
+                ->orderBy('l.lastname', 'ASC')
+                ->addOrderBy('l.firstname', 'ASC')
+                ->setMaxResults(200),
+        ]);
+
+        $builder->add('company', EntityType::class, [
+            'class'         => Company::class,
+            'choice_label'  => 'name',
+            'label'         => 'mautomic_crm.deal.company',
+            'label_attr'    => ['class' => 'control-label'],
+            'attr'          => ['class' => 'form-control'],
+            'required'      => false,
+            'placeholder'   => '',
+            'query_builder' => fn (CompanyRepository $repo) => $repo->createQueryBuilder('c')
+                ->orderBy('c.name', 'ASC')
+                ->setMaxResults(200),
         ]);
 
         $builder->add(

--- a/Resources/views/Deal/details.html.twig
+++ b/Resources/views/Deal/details.html.twig
@@ -36,7 +36,35 @@
   <div class="box-layout">
       <div class="col-md-9 height-auto">
           <div>
-              {% include '@MauticCore/Helper/description--expanded.html.twig' with {'description': item.description} %}
+              <div class="row">
+                  <div class="col-md-5">
+                      {% include '@MauticCore/Helper/description--expanded.html.twig' with {'description': item.description} %}
+                  </div>
+                  <div class="col-md-7 pa-md">
+                      <div class="row">
+                          <div class="col-md-6">
+                              <span class="fw-b text-muted">{{ 'mautomic_crm.deal.contact'|trans }}</span><br>
+                              {% if item.contact %}
+                                  <a href="{{ path('mautic_contact_action', {'objectAction': 'view', 'objectId': item.contact.id}) }}">
+                                      <i class="fa fa-user"></i> {{ item.contact.name ?: item.contact.email ?: 'Contact #' ~ item.contact.id }}
+                                  </a>
+                              {% else %}
+                                  <span class="text-muted">-</span>
+                              {% endif %}
+                          </div>
+                          <div class="col-md-6">
+                              <span class="fw-b text-muted">{{ 'mautomic_crm.deal.company'|trans }}</span><br>
+                              {% if item.company %}
+                                  <a href="{{ path('mautic_company_action', {'objectAction': 'view', 'objectId': item.company.id}) }}">
+                                      <i class="fa fa-building"></i> {{ item.company.name }}
+                                  </a>
+                              {% else %}
+                                  <span class="text-muted">-</span>
+                              {% endif %}
+                          </div>
+                      </div>
+                  </div>
+              </div>
 
               <div class="collapse pr-md pl-md" id="deal-details">
                   <div class="pr-md pl-md pb-md">

--- a/Resources/views/Deal/form.html.twig
+++ b/Resources/views/Deal/form.html.twig
@@ -20,6 +20,10 @@
                 <div class="col-md-3">{{ form_row(form.currency) }}</div>
             </div>
             <div class="row">
+                <div class="col-md-6">{{ form_row(form.contact) }}</div>
+                <div class="col-md-6">{{ form_row(form.company) }}</div>
+            </div>
+            <div class="row">
                 <div class="col-md-12">{{ form_row(form.description) }}</div>
             </div>
             <div class="row">


### PR DESCRIPTION
## Summary
- Adds Contact and Company dropdown fields to the deal edit form (side by side above description)
- Shows Contact and Company with labels and links on the deal detail view next to the description

Closes #17