### PR TITLE
Move Task Queues to sub-navigation on Tasks page

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -133,12 +133,6 @@ return [
                 'parent'   => 'mautomic_crm.crm',
                 'priority' => 30,
             ],
-            'mautomic_crm.task_queues' => [
-                'route'    => 'mautic_mautomic_crm_task_queue_index',
-                'access'   => 'mautomic_crm:tasks:view',
-                'parent'   => 'mautomic_crm.crm',
-                'priority' => 31,
-            ],
         ],
         'admin' => [
             'mautomic_crm.settings' => [

--- a/Resources/views/Task/_subnav.html.twig
+++ b/Resources/views/Task/_subnav.html.twig
@@ -1,0 +1,15 @@
+{# Sub-navigation for Tasks section #}
+{% set activeTab = activeTab|default('tasks') %}
+
+<ul class="nav nav-pills mb-md">
+    <li{% if activeTab == 'tasks' %} class="active"{% endif %}>
+        <a href="{{ path('mautic_mautomic_crm_task_index') }}" data-toggle="ajax">
+            {{ 'mautomic_crm.tasks'|trans }}
+        </a>
+    </li>
+    <li{% if activeTab == 'queues' %} class="active"{% endif %}>
+        <a href="{{ path('mautic_mautomic_crm_task_queue_index') }}" data-toggle="ajax">
+            {{ 'mautomic_crm.task_queues'|trans }}
+        </a>
+    </li>
+</ul>

--- a/Resources/views/Task/list.html.twig
+++ b/Resources/views/Task/list.html.twig
@@ -9,6 +9,8 @@
 
 {% block content %}
   {% if isIndex %}
+    {{ include('@MautomicCrm/Task/_subnav.html.twig', {'activeTab': 'tasks'}) }}
+
     <div id="page-list-wrapper" class="{% if items|length > 0 or searchValue is not empty %}panel {% endif %}panel-default">
         {{ include('@MauticCore/Helper/list_toolbar.html.twig', {
             'searchValue': searchValue,

--- a/Resources/views/TaskQueue/list.html.twig
+++ b/Resources/views/TaskQueue/list.html.twig
@@ -5,10 +5,12 @@
 
 {% block mauticContent %}mautomic_crm_task_queue{% endblock %}
 
-{% block headerTitle %}{{ 'mautomic_crm.task_queues'|trans }}{% endblock %}
+{% block headerTitle %}{{ 'mautomic_crm.tasks'|trans }}{% endblock %}
 
 {% block content %}
   {% if isIndex %}
+    {{ include('@MautomicCrm/Task/_subnav.html.twig', {'activeTab': 'queues'}) }}
+
     <div id="page-list-wrapper" class="{% if items|length > 0 or searchValue is not empty %}panel {% endif %}panel-default">
         {{ include('@MauticCore/Helper/list_toolbar.html.twig', {
             'searchValue': searchValue,


### PR DESCRIPTION
## Summary
- Remove Task Queues from the CRM sidebar menu
- Add pill-style sub-navigation below the Tasks header with "Tasks" and "Task Queues" tabs
- Both Tasks and Task Queues list pages share the same sub-nav partial
- Extensible for future buttons/tabs

## Test plan
- [x] 128 unit + 97 functional tests pass