### PR TITLE
feat: add task link on deal detail page

### DIFF
--- a/Controller/TaskController.php
+++ b/Controller/TaskController.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace MauticPlugin\MautomicCrmBundle\Controller;
 
 use Mautic\CoreBundle\Controller\AbstractStandardFormController;
+use MauticPlugin\MautomicCrmBundle\Entity\Deal;
+use MauticPlugin\MautomicCrmBundle\Entity\Task;
+use MauticPlugin\MautomicCrmBundle\Model\TaskModel;
 use MauticPlugin\MautomicCrmBundle\Model\TaskQueueModel;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -53,6 +56,12 @@ class TaskController extends AbstractStandardFormController
      */
     public function newAction(Request $request)
     {
+        $dealId = (int) $request->query->get('dealId', '0');
+
+        if ($dealId > 0) {
+            return $this->newWithDeal($request, $dealId);
+        }
+
         return parent::newStandard($request);
     }
 
@@ -61,6 +70,12 @@ class TaskController extends AbstractStandardFormController
      */
     public function editAction(Request $request, int|string $objectId, bool $ignorePost = false)
     {
+        $dealId = (int) $request->query->get('dealId', '0');
+
+        if ($dealId > 0) {
+            return $this->editWithDeal($request, (int) $objectId, $dealId, $ignorePost);
+        }
+
         return parent::editStandard($request, $objectId, $ignorePost);
     }
 
@@ -142,5 +157,121 @@ class TaskController extends AbstractStandardFormController
                 'flashes' => $flashes,
             ])
         );
+    }
+
+    /**
+     * @return JsonResponse|RedirectResponse|Response
+     */
+    private function newWithDeal(Request $request, int $dealId)
+    {
+        /** @var TaskModel $model */
+        $model  = $this->getModel('mautomic_crm.task');
+        $entity = $model->getEntity();
+        \assert($entity instanceof Task);
+
+        $deal = $this->getModel('mautomic_crm.deal')->getEntity($dealId);
+        if ($deal instanceof Deal) {
+            $entity->setDeal($deal);
+            if (null !== $deal->getContact()) {
+                $entity->setContact($deal->getContact());
+            }
+        }
+
+        $action = $this->generateUrl('mautic_mautomic_crm_task_action', [
+            'objectAction' => 'new',
+            'dealId'       => $dealId,
+        ]);
+        $form = $model->createForm($entity, $this->formFactory, $action);
+
+        if (Request::METHOD_POST === $request->getMethod()) {
+            if (!$cancelled = $this->isFormCancelled($form)) {
+                if ($this->isFormValid($form)) {
+                    $model->saveEntity($entity);
+
+                    return $this->redirectToDeal($entity, $dealId);
+                }
+            }
+
+            if ($cancelled) {
+                return $this->redirectToDeal($entity, $dealId);
+            }
+        }
+
+        return $this->delegateView([
+            'viewParameters' => [
+                'form'   => $form->createView(),
+                'entity' => $entity,
+            ],
+            'contentTemplate' => '@MautomicCrm/Task/form.html.twig',
+            'passthroughVars' => [
+                'mauticContent' => 'mautomic_crm_task',
+                'route'         => $action,
+            ],
+        ]);
+    }
+
+    /**
+     * @return JsonResponse|RedirectResponse|Response
+     */
+    private function editWithDeal(Request $request, int $objectId, int $dealId, bool $ignorePost = false)
+    {
+        /** @var TaskModel $model */
+        $model  = $this->getModel('mautomic_crm.task');
+        $entity = $model->getEntity($objectId);
+
+        if (null === $entity) {
+            return $this->redirectToDeal(null, $dealId);
+        }
+
+        $action = $this->generateUrl('mautic_mautomic_crm_task_action', [
+            'objectAction' => 'edit',
+            'objectId'     => $objectId,
+            'dealId'       => $dealId,
+        ]);
+        $form = $model->createForm($entity, $this->formFactory, $action);
+
+        if (Request::METHOD_POST === $request->getMethod() && !$ignorePost) {
+            if (!$cancelled = $this->isFormCancelled($form)) {
+                if ($this->isFormValid($form)) {
+                    $model->saveEntity($entity);
+
+                    return $this->redirectToDeal($entity, $dealId);
+                }
+            }
+
+            if ($cancelled) {
+                return $this->redirectToDeal($entity, $dealId);
+            }
+        }
+
+        return $this->delegateView([
+            'viewParameters' => [
+                'form'   => $form->createView(),
+                'entity' => $entity,
+            ],
+            'contentTemplate' => '@MautomicCrm/Task/form.html.twig',
+            'passthroughVars' => [
+                'mauticContent' => 'mautomic_crm_task',
+                'route'         => $action,
+            ],
+        ]);
+    }
+
+    private function redirectToDeal(?Task $entity, int $dealId): RedirectResponse
+    {
+        $resolvedDealId = $dealId;
+
+        if ($resolvedDealId < 1 && null !== $entity && null !== $entity->getDeal()) {
+            $resolvedDealId = (int) $entity->getDeal()->getId();
+        }
+
+        if ($resolvedDealId > 0) {
+            return $this->redirect($this->generateUrl('mautic_mautomic_crm_deal_action', [
+                'objectAction' => 'view',
+                'objectId'     => $resolvedDealId,
+            ]));
+        }
+
+        return $this->redirect($this->generateUrl('mautic_mautomic_crm_task_index'));
     }
 }

--- a/Resources/views/Deal/details.html.twig
+++ b/Resources/views/Deal/details.html.twig
@@ -166,7 +166,12 @@
           {% endif %}
 
           <div class="pa-md">
-              <h4>{{ 'mautomic_crm.deal.tasks'|trans }}</h4>
+              <h4>
+                  {{ 'mautomic_crm.deal.tasks'|trans }}
+                  <a class="btn btn-primary btn-xs pull-right" href="{{ path('mautic_mautomic_crm_task_action', {'objectAction': 'new', 'dealId': item.id}) }}">
+                      <i class="ri-add-line"></i> {{ 'mautomic_crm.task.add'|trans }}
+                  </a>
+              </h4>
               {% if tasks is defined and tasks|length > 0 %}
                   <table class="table table-hover">
                       <thead>

--- a/Tests/Functional/Controller/TaskDealLinkingTest.php
+++ b/Tests/Functional/Controller/TaskDealLinkingTest.php
@@ -103,6 +103,80 @@ class TaskDealLinkingTest extends MauticMysqlTestCase
         $this->assertGreaterThan(0, $crawler->filter('#task_contact')->count(), 'Contact dropdown should exist');
     }
 
+    public function testDealDetailShowsAddTaskButton(): void
+    {
+        $pipeline = $this->createPipelineWithStage();
+
+        $deal = new Deal();
+        $deal->setName('Add Task Button Deal');
+        $deal->setPipeline($pipeline);
+        $deal->setStage($pipeline->getStages()->first());
+        $deal->setIsPublished(true);
+        $this->em->persist($deal);
+        $this->em->flush();
+
+        $crawler  = $this->client->request(Request::METHOD_GET, '/s/mautomic/deals/view/'.$deal->getId());
+        $response = $this->client->getResponse();
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertStringContainsString('Add Task', $response->getContent());
+
+        $addTaskLinks = $crawler->filter('a[href*="dealId='.$deal->getId().'"]');
+        $this->assertGreaterThan(0, $addTaskLinks->count(), 'Add Task button should link with dealId parameter');
+    }
+
+    public function testNewTaskFromDealPreSelectsDeal(): void
+    {
+        $pipeline = $this->createPipelineWithStage();
+
+        $deal = new Deal();
+        $deal->setName('Pre-select Deal');
+        $deal->setPipeline($pipeline);
+        $deal->setStage($pipeline->getStages()->first());
+        $deal->setIsPublished(true);
+        $this->em->persist($deal);
+        $this->em->flush();
+
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/mautomic/tasks/new?dealId='.$deal->getId());
+
+        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+
+        $dealSelect = $crawler->filter('#task_deal');
+        $this->assertGreaterThan(0, $dealSelect->count(), 'Deal dropdown should exist');
+
+        $selectedOption = $crawler->filter('#task_deal option[selected]');
+        if ($selectedOption->count() > 0) {
+            $this->assertSame((string) $deal->getId(), $selectedOption->attr('value'), 'Deal should be pre-selected');
+        }
+    }
+
+    public function testEditTaskFromDealShowsForm(): void
+    {
+        $pipeline = $this->createPipelineWithStage();
+
+        $deal = new Deal();
+        $deal->setName('Edit Task Deal');
+        $deal->setPipeline($pipeline);
+        $deal->setStage($pipeline->getStages()->first());
+        $deal->setIsPublished(true);
+        $this->em->persist($deal);
+
+        $task = new Task();
+        $task->setTitle('Task to edit from deal');
+        $task->setDeal($deal);
+        $task->setStatus('open');
+        $task->setPriority('normal');
+        $task->setIsPublished(true);
+        $this->em->persist($task);
+
+        $this->em->flush();
+
+        $this->client->request(Request::METHOD_GET, '/s/mautomic/tasks/edit/'.$task->getId().'?dealId='.$deal->getId());
+
+        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertStringContainsString('Task to edit from deal', $this->client->getResponse()->getContent());
+    }
+
     private function createPipelineWithStage(): Pipeline
     {
         $pipeline = new Pipeline();

--- a/Translations/en_US/messages.ini
+++ b/Translations/en_US/messages.ini
@@ -131,6 +131,7 @@ mautomic_crm.deal_field.noresults.tip="Define custom fields to capture additiona
 mautomic_crm.deal_field.list="Deal Fields"
 mautomic_crm.deal_field.name.required="Field label is required."
 mautomic_crm.deal_field.alias.required="Field alias is required."
+mautomic_crm.task.add="Add Task"
 mautomic_crm.task.reminder_date="Reminder"
 mautomic_crm.task.reminder_sent="Sent"
 mautomic_crm.task_queues="Task Queues"


### PR DESCRIPTION
## Summary
- Add "Add Task" button on the Deal detail page (next to the Tasks heading) that links to the task creation form with the deal pre-selected
- When creating or editing a task from a deal context (`?dealId=N`), the deal is pre-selected in the form and the user is redirected back to the deal page after save or cancel
- Also pre-populates the contact field from the deal's contact when creating a new task from a deal
- Follows the same pattern as the existing NoteController deal-linking behavior

Closes #38

## Test plan
- [x] Unit tests pass (128 tests, 243 assertions)
- [x] Functional tests pass (100 tests, 281 assertions) including 3 new tests:
  - `testDealDetailShowsAddTaskButton` - verifies the Add Task button appears with correct dealId link
  - `testNewTaskFromDealPreSelectsDeal` - verifies deal is pre-selected in the form
  - `testEditTaskFromDealShowsForm` - verifies editing a task from deal context works
- [x] PHPStan level 6 passes on changed files
- [ ] Browser smoke test: navigate to a deal detail page, click "Add Task", verify deal is pre-selected, save, verify redirect back to deal